### PR TITLE
Require Craft 3 RC1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "craft-plugin"
     ],
     "require": {
+        "craftcms/cms": "^3.0.0-RC1",
         "webonyx/graphql-php": "^0.10.0",
         "react/http": "^0.7"
     },


### PR DESCRIPTION
The Plugin Store is eventually going to require that plugins define their Craft CMS compatibility, via the `require` property in composer.json.