### PR TITLE
Fix hardcoded admin links

### DIFF
--- a/src/Controllers/CpController.php
+++ b/src/Controllers/CpController.php
@@ -17,7 +17,7 @@ class CpController extends Controller
         $token->token = Yii::$app->security->generateRandomString(64);
         $token->save();
 
-        $this->redirect('/admin/settings/plugins/craftql');
+        $this->redirect('settings/plugins/craftql');
     }
 
     function actionTokendelete($tokenId)
@@ -25,7 +25,7 @@ class CpController extends Controller
         $token = Token::find()->where(['id' => $tokenId])->one();
         $token->delete();
 
-        $this->redirect('/admin/settings/plugins/craftql');
+        $this->redirect('settings/plugins/craftql');
     }
 
     function actionTokenscopes($tokenId)
@@ -44,7 +44,7 @@ class CpController extends Controller
 
         Craft::$app->getSession()->setNotice(Craft::t('app', 'Scopes saved.'));
 
-        $this->redirect('/admin/craftql/token/'.$tokenId.'/scopes');
+        $this->redirect('craftql/token/'.$tokenId.'/scopes');
     }
 
     function actionIndex()

--- a/src/templates/scopes.html
+++ b/src/templates/scopes.html
@@ -4,9 +4,9 @@
 {% set fullPageForm = true %}
 {% set title = "Token Scopes"|t %}
 {% set crumbs = [
-    {'label': 'Settings', 'url': '/admin/settings'},
-    {'label': 'Plugins', 'url': '/admin/settings/plugins'},
-    {'label': 'CraftQL', 'url': '/admin/settings/plugins/craftql'},
+    {'label': 'Settings', 'url': url('settings')},
+    {'label': 'Plugins', 'url': url('settings/plugins')},
+    {'label': 'CraftQL', 'url': url('settings/plugins/craftql')},
 ] %}
 
 {% set content %}
@@ -23,7 +23,7 @@
 </style>
 <div class="fieldlayoutform">
     <h2>Try it out</h2>
-    <p>You can explore your API with the permissions of this token by navigating to <a href="/admin/craftql/browse/{{ token.token }}">/admin/craftql/browse/{token}</a>.
+    <p>You can explore your API with the permissions of this token in <a href="{{ url('craftql/browse/' ~ token.token ) }}">GraphiQL</a>.
 </div>
 
 <hr>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -48,13 +48,13 @@ For example, if you had a section named `news` you could ask _CraftQL_ for five 
 
 You can access your GraphQL endpoint in two ways,
 
-1. **[GraphiQL](/admin/craftql/browse)** <p>will show you a graphical interface to GraphQL. Use it to explore your schema and test requests. Click _Docs_ in the upper right hand corner to see all the fields you can query against.</p>
+1. **[GraphiQL]({{ url('craftql/browse') }})** <p>will show you a graphical interface to GraphQL. Use it to explore your schema and test requests. Click _Docs_ in the upper right hand corner to see all the fields you can query against.</p>
 
 2. **Curl**
 {% if settings.tokens|length %}<p>You can query your schema directly by passing a GraphQL statement throuh a `query` variable. The following Curl statement should get you started,</p>
 <p><pre style="background: whiteSmoke; padding: 15px;"><code class="shell">$ curl -H "Authorization: bearer {{ settings.tokens[0].token|default('{TOKEN}') }}" -H "Content-type: application/json" -d '{"query":"{ helloWorld }"}' {{ siteUrl }}{{ settings.uri }}</code></pre></p>
 {% else %}
-<p>Before you can use Curl you need to [add a token](/admin/craftql/token-gen) for authenticated access in to Craft.</p>
+<p>Before you can use Curl you need to [add a token]({{ url('craftql/token-gen') }}) for authenticated access in to Craft.</p>
 {% endif %}
 {% endset %}
 
@@ -77,7 +77,7 @@ You can access your GraphQL endpoint in two ways,
     <h2>Tokens</h2>
     <p>Tokens control access in to your API. Instead of authenticating with a username and password, API access is granted via a token. Treat this token like a password because it provides privileged access in to your Craft website.</p>
 
-    <p><a href="/admin/craftql/token-gen">Generate a new token</a> (for my user)</p>
+    <p><a href="{{ url('craftql/token-gen') }}">Generate a new token</a> (for my user)</p>
 
     {% if settings.tokens|length > 0 %}
     <table class="data fullwidth collapsible">
@@ -93,8 +93,8 @@ You can access your GraphQL endpoint in two ways,
             <tr>
                 <td><input type="text" name="token[{{ token.id }}][name]" class="text" placeholder="Name..." value="{{ token.name }}" /></td>
                 <td>{{ token.token }}</td>
-                <td><a href="/admin/craftql/token/{{ token.id }}/scopes">Scopes&hellip;</a></td>
-                <td><a class="delete icon" title="Delete" role="button" href="/admin/craftql/token-del/{{ token.id }}"></a></td>
+                <td><a href="{{ url('craftql/token/' ~ token.id ~ '/scopes') }}">Scopes&hellip;</a></td>
+                <td><a class="delete icon" title="Delete" role="button" href="{{ url('craftql/token-del/' ~ token.id) }}"></a></td>
             </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
This fixes links that were hardcoded to a root relative "/admin" url. Control panels can exists at different segments, so this is not reliable.

Craft's `url` and `redirect` methods are context-aware of the control panel, so plugins should pass relative paths a the link will automatically be made relative to the CP.