### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,12 +350,12 @@ If your custom field resolves an object you can expose that to CraftQL as well. 
 Event::on(\craft\base\Field::class, 'craftQlGetFieldSchema', function ($event) {
   $field = $event->sender;
 
-  $object = $event->schema->createObjectType('MapPoint')
+  $object = $event->schema->createObjectType(ucfirst($field->handle) . 'MapPoint')
         ->addStringField('lat')
         ->addStringField('lng')
         ->addStringField('zoom');
 
-  $event->schema->addObjectField($field, $object);
+  $event->schema->addField($field)->type($object);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ If your custom field resolves an object you can expose that to CraftQL as well. 
 Event::on(\craft\base\Field::class, 'craftQlGetFieldSchema', function ($event) {
   $field = $event->sender;
 
-  $object = $event->schema->createObjectType(ucfirst($field->handle) . 'MapPoint')
+  $object = $event->schema->createObjectType('MapPoint')
         ->addStringField('lat')
         ->addStringField('lng')
         ->addStringField('zoom');


### PR DESCRIPTION
The last example in the section "Third-pary Field Support" seems to be outdated.

Also there seems to be no way to define object schemas globally and to reuse them. So in the example the Schema `MapPoint` gets recreated for each field and will lead to an error as multiple schemas with the same name exist?