### PR TITLE
Correct handling of malformed tokens with compliant 401 response according to RFC 6750

### DIFF
--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -125,7 +125,6 @@ class ApiController extends Controller
 
         // You must set the header to JSON, otherwise Craft will see HTML and try to insert
         // javascript at the bottom to run pending tasks
-        $response = \Craft::$app->getResponse();
         $response->headers->add('Content-Type', 'application/json; charset=UTF-8');
 
         return $this->asJson($result);

--- a/src/Models/Token.php
+++ b/src/Models/Token.php
@@ -4,7 +4,6 @@ namespace markhuot\CraftQL\Models;
 
 use Craft;
 use craft\db\ActiveRecord;
-use Firebase\JWT\ExpiredException;
 use GraphQL\Error\UserError;
 use markhuot\CraftQL\CraftQL;
 
@@ -59,12 +58,7 @@ class Token extends ActiveRecord
 
         // If the token matches a JWT format
         if (preg_match('/[^.]+\.[^.]+\.[^.]+/', $token)) {
-            try {
-                $tokenData = CraftQL::getInstance()->jwt->decode($token);
-            }
-            catch (ExpiredException $e) {
-                throw new UserError('The token has expired');
-            }
+            $tokenData = CraftQL::getInstance()->jwt->decode($token);
             $user = \craft\elements\User::find()->id($tokenData->id)->one();
             $token = Token::forUser($user);
             return $token;


### PR DESCRIPTION
invalid_token

The access token provided is expired, revoked, malformed, or invalid for other reasons. The resource SHOULD respond with the HTTP 401 (Unauthorized) status code. The client MAY request a new access token and retry the protected resource request.