### PR TITLE
Add volumeId to VolumeInterface

### DIFF
--- a/src/Types/VolumeInterface.php
+++ b/src/Types/VolumeInterface.php
@@ -20,6 +20,7 @@ class VolumeInterface extends InterfaceBuilder {
 
         $this->addIntField('size');
         $this->addField('folder')->type(VolumeFolder::class);
+        $this->addStringField('volumeId');
         $this->addStringField('mimeType');
         $this->addStringField('title');
         $this->addStringField('extension');


### PR DESCRIPTION
This is already available from `folder.volumeId`, but it seems useful to just know what volume an asset is in without going through the folder.