### PR TITLE
Graphiql url override

### DIFF
--- a/src/Controllers/CpController.php
+++ b/src/Controllers/CpController.php
@@ -55,28 +55,28 @@ class CpController extends Controller
 
     function actionGraphiql()
     {
-        $url = \craft\helpers\UrlHelper::baseRequestUrl();
         $instance = \markhuot\CraftQL\CraftQL::getInstance();
+        $baseUrl = $instance->settings->baseUrl ?? \craft\helpers\UrlHelper::siteUrl();
         $uri = $instance->settings->uri;
 
         $this->view->registerAssetBundle(GraphiQLAssetBundle::class);
 
         $this->renderTemplate('craftql/graphiql', [
-            'url' => "{$url}{$uri}",
+            'url' => "{$baseUrl}{$uri}",
             'token' => false,
         ]);
     }
 
     function actionGraphiqlas($token)
     {
-        $url = \craft\helpers\UrlHelper::baseRequestUrl();
         $instance = \markhuot\CraftQL\CraftQL::getInstance();
+        $baseUrl = $instance->settings->baseUrl ?? \craft\helpers\UrlHelper::siteUrl();
         $uri = $instance->settings->uri;
 
         $this->view->registerAssetBundle(GraphiQLAssetBundle::class);
 
         $this->renderTemplate('craftql/graphiql', [
-            'url' => "{$url}{$uri}",
+            'url' => "{$baseUrl}{$uri}",
             'token' => $token,
         ]);
     }

--- a/src/Controllers/CpController.php
+++ b/src/Controllers/CpController.php
@@ -55,7 +55,7 @@ class CpController extends Controller
 
     function actionGraphiql()
     {
-        $url = \craft\helpers\UrlHelper::siteUrl();
+        $url = \craft\helpers\UrlHelper::baseRequestUrl();
         $instance = \markhuot\CraftQL\CraftQL::getInstance();
         $uri = $instance->settings->uri;
 
@@ -69,7 +69,7 @@ class CpController extends Controller
 
     function actionGraphiqlas($token)
     {
-        $url = \craft\helpers\UrlHelper::siteUrl();
+        $url = \craft\helpers\UrlHelper::baseRequestUrl();
         $instance = \markhuot\CraftQL\CraftQL::getInstance();
         $uri = $instance->settings->uri;
 

--- a/src/Controllers/CpController.php
+++ b/src/Controllers/CpController.php
@@ -56,13 +56,13 @@ class CpController extends Controller
     function actionGraphiql()
     {
         $instance = \markhuot\CraftQL\CraftQL::getInstance();
-        $baseUrl = $instance->settings->baseUrl ?? \craft\helpers\UrlHelper::siteUrl();
+        $graphiqlFetchUrl = $instance->settings->graphiqlFetchUrl ?? \craft\helpers\UrlHelper::siteUrl();
         $uri = $instance->settings->uri;
 
         $this->view->registerAssetBundle(GraphiQLAssetBundle::class);
 
         $this->renderTemplate('craftql/graphiql', [
-            'url' => "{$baseUrl}{$uri}",
+            'url' => "{$graphiqlFetchUrl}{$uri}",
             'token' => false,
         ]);
     }
@@ -70,13 +70,13 @@ class CpController extends Controller
     function actionGraphiqlas($token)
     {
         $instance = \markhuot\CraftQL\CraftQL::getInstance();
-        $baseUrl = $instance->settings->baseUrl ?? \craft\helpers\UrlHelper::siteUrl();
+        $graphiqlFetchUrl = $instance->settings->graphiqlFetchUrl ?? \craft\helpers\UrlHelper::siteUrl();
         $uri = $instance->settings->uri;
 
         $this->view->registerAssetBundle(GraphiQLAssetBundle::class);
 
         $this->renderTemplate('craftql/graphiql', [
-            'url' => "{$baseUrl}{$uri}",
+            'url' => "{$graphiqlFetchUrl}{$uri}",
             'token' => $token,
         ]);
     }

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -7,6 +7,7 @@ use markhuot\CraftQL\Models\Token;
 
 class Settings extends Model
 {
+    public $baseUrl = null;
     public $uri = 'api';
     public $verbs = ['POST'];
     public $allowedOrigins = [];

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -7,7 +7,7 @@ use markhuot\CraftQL\Models\Token;
 
 class Settings extends Model
 {
-    public $baseUrl = null;
+    public $graphiqlFetchUrl = null; // defaults to siteUrl via CpController
     public $uri = 'api';
     public $verbs = ['POST'];
     public $allowedOrigins = [];


### PR DESCRIPTION
This adds  an optional `baseUrl` setting, that will be used instead of `\craft\helpers\UrlHelper::siteUrl()` when making GraphiQL requests in the CP.

## Why?

My current setup (which doesn't seem entirely uncommon when using Craft headless), has CP access at `cms.site.com`, with Craft site URLs at `site.com`, `site.co.uk`, etc.

The Craft site URLs (`site.com`, `site.co.uk`) are strictly frontend SPAs (not hosting Craft/PHP), so all CP access and CraftQL requests go to `cms.site.com` (which is not a "Craft Site url).

Therefore, GraphiQL didn't work, because it relied on `\craft\helpers\UrlHelper::siteUrl()`, which matches the site from the current url, falling back to your default site (`site.com`). So, it was falling back to making requests to `site.com/api`, which doesn't exist (it always needs to go to `cms.site.com/api`).

With this `baseUrl` available, in a setup like mine, I can keep things working with a config file like so:

```
<?php

return [
    'baseUrl' => \craft\helpers\UrlHelper::baseRequestUrl(),
    'allowedOrigins' => [
        '*'
    ]
];
```