### PR TITLE
Custom authorization header functionality

### DIFF
--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -149,17 +149,31 @@ class ApiController extends Controller
 
     private static function findToken($authorizationHeader, $headers)
     {
-        if ($authorizationHeader) {
-            $tokenId = $headers->get($authorizationHeader);
+        // Default, for cases when token header is not found to use user based token
+        // resolution, if possible.
+        $tokenId = null;
 
-            if (!$tokenId) {
-                return false;
+        $hadHeader = false;
+
+        if ($authorizationHeader) {
+            if ($headers->has($authorizationHeader)) {
+                $hadHeader = true;
+
+                $tokenId = $headers->get($authorizationHeader);
             }
-        } else {
+        } else if ($headers->has('authorization')) {
+            $hadHeader = true;
+
             $authorization = $headers->get('authorization');
             preg_match('/^(?:b|B)earer\s+(?<tokenId>.+)/', $authorization, $matches);
             $tokenId = @$matches['tokenId'];
         }
+
+        /*
+        if ($hadHeader && !$tokenId) {
+            return false;
+        }
+        */
 
         return Token::findId($tokenId);
     }

--- a/src/Controllers/CpController.php
+++ b/src/Controllers/CpController.php
@@ -64,6 +64,7 @@ class CpController extends Controller
         $this->renderTemplate('craftql/graphiql', [
             'url' => "{$url}{$uri}",
             'token' => false,
+            'authorizationHeader' => $instance->settings->authorizationHeader,
         ]);
     }
 

--- a/src/Controllers/CpController.php
+++ b/src/Controllers/CpController.php
@@ -78,6 +78,7 @@ class CpController extends Controller
         $this->renderTemplate('craftql/graphiql', [
             'url' => "{$url}{$uri}",
             'token' => $token,
+            'authorizationHeader' => $instance->settings->authorizationHeader,
         ]);
     }
 }

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -7,6 +7,7 @@ use markhuot\CraftQL\Models\Token;
 
 class Settings extends Model
 {
+    public $authorizationHeader = '';
     public $uri = 'api';
     public $verbs = ['POST'];
     public $allowedOrigins = [];

--- a/src/templates/graphiql.html
+++ b/src/templates/graphiql.html
@@ -148,9 +148,9 @@
           headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            {% if authorizationHeader %}
+            {% if authorizationHeader and token %}
             '{{ authorizationHeader }}': '{{ token }}',
-            {% else %}
+            {% elseif token %}
             'Authorization': 'Bearer {{ token }}',
             {% endif %}
           },

--- a/src/templates/graphiql.html
+++ b/src/templates/graphiql.html
@@ -148,7 +148,11 @@
           headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
+            {% if authorizationHeader %}
+            '{{ authorizationHeader }}': '{{ token }}',
+            {% else %}
             'Authorization': 'Bearer {{ token }}',
+            {% endif %}
           },
           body: JSON.stringify(graphQLParams),
           credentials: 'include',

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -74,7 +74,7 @@ You can access your GraphQL endpoint in two ways,
         first: true,
         name: 'authorizationHeader',
         value: settings.authorizationHeader,
-        instructions: 'Custom header to be used check for authorization token. Useful if site is behind Basic Auth.'
+        instructions: 'Custom header to be used to check for authorization token. Useful if site is behind Basic Auth and conflicts with default Authorization Bearer.'
     }) }}
 
     <h2>URI</h2>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -68,6 +68,15 @@ You can access your GraphQL endpoint in two ways,
     <hr>
 
 <div class="" style="width: 70%">
+    <h2>Custom Authorization Header</h2>
+
+    {{ forms.textField({
+        first: true,
+        name: 'authorizationHeader',
+        value: settings.authorizationHeader,
+        instructions: 'Custom header to be used check for authorization token. Useful if site is behind Basic Auth.'
+    }) }}
+
     <h2>URI</h2>
 
     {{ forms.textField({


### PR DESCRIPTION
I have a setup where CraftCMS is used in fully headless fashion and our development/production host is behind Basic Auth.

Currently, if you're behind Basic Auth, it's impossible to auth with CraftQL, because it uses Authorization header value (as it is already used for Basic Auth).  
Specifying multiple values, like `Authorization: Basic <base64>, Bearer <token>` is against spec.

Therefore, I implemented feature to provide custom Authorization header.