### PR TITLE
Fix element query deprecation errors

### DIFF
--- a/src/Types/CategoryInterface.php
+++ b/src/Types/CategoryInterface.php
@@ -60,7 +60,7 @@ class CategoryInterface extends InterfaceBuilder {
             $criteria = $criteria->{$key}($value);
         }
 
-        return $criteria;
+        return $criteria->all();
     }
 
 }

--- a/src/Types/EntryInterface.php
+++ b/src/Types/EntryInterface.php
@@ -31,21 +31,34 @@ class EntryInterface extends InterfaceBuilder {
             $this->addField('type')->type(EntryType::class);
         }
 
-        $this->addField('ancestors')->lists()->type(EntryInterface::class);
+        $this->addField('ancestors')->lists()->type(EntryInterface::class)
+            ->resolve(function ($root) {
+                return $root->getAncestors()->all();
+            });
 
         $this->addField('children')
             ->lists()
             ->type(EntryInterface::class)
             ->use(new EntryQueryArguments)
             ->resolve(function ($root, $args, $context, $info) {
-                return $this->request->entries($root->{$info->fieldName}, $root, $args, $context, $info);
+                return $this->request->entries($root->{$info->fieldName}, $root, $args, $context, $info)->all();
             });
 
-        $this->addField('descendants')->lists()->type(EntryInterface::class);
+        $this->addField('descendants')->lists()->type(EntryInterface::class)
+            ->resolve(function ($root) {
+                return $root->getDescendants()->all();
+            });
+
         $this->addBooleanField('hasDescendants')->nonNull();
         $this->addIntField('level');
+
         $this->addField('parent')->type(EntryInterface::class);
-        $this->addField('siblings')->lists()->type(EntryInterface::class);
+
+        $this->addField('siblings')->lists()->type(EntryInterface::class)
+            ->resolve(function ($root) {
+                return $root->getSiblings()->all();
+            });
+
     }
 
     function getResolveType() {

--- a/src/Types/Mutation.php
+++ b/src/Types/Mutation.php
@@ -129,7 +129,7 @@ class Mutation extends Schema {
         //     'resolve' => function ($root, $args) {
         //         $entry = \craft\elements\Entry::find();
         //         $entry->id($args['id']);
-        //         $entry = $entry->first();
+        //         $entry = $entry->one();
 
         //         $json = json_decode($args['json'], true);
         //         $fieldData = [];

--- a/src/Types/Query.php
+++ b/src/Types/Query.php
@@ -310,7 +310,7 @@ class Query extends Schema {
             ->type(CategoryInterface::class)
             ->use(new CategoryQueryArguments)
             ->resolve(function ($root, $args) use ($categoryResolver) {
-                return $categoryResolver($root, $args)->first();
+                return $categoryResolver($root, $args)->one();
             });
 
         $this->addField('categoriesConnection')
@@ -351,7 +351,7 @@ class Query extends Schema {
             ->type(User::class)
             ->use(new UserQueryArguments)
             ->resolve(function ($root, $args) use ($userResolver) {
-                return $userResolver($root, $args)->first();
+                return $userResolver($root, $args)->one();
             });
     }
 


### PR DESCRIPTION
In several cases, there were implicit accessors to things like `$root->children` without an `->all()` resolver, leading to deprecation errors. This fixes that.

Ultimately, it may make more sense to add all the structure/nested-set based fields (`children`, `ancestors`, etc.) to `markhuot\CraftQL\Builders\InterfaceBuilder\ElementInterface`, as in Craft, they are part of `craft\base\Element` / `craft\base\ElementInterface`.

This would probably make things easier to maintain and make things more consistent for users. For example – `markhuot\CraftQL\Builders\InterfaceBuilder\CategoryInterface` only has `children`, but it _could_ have `ancestors`, `parent`, and all the rest, like `markhuot\CraftQL\Builders\InterfaceBuilder\EntryInterface` does.