### PR TITLE
WIP: Add GetSchemaBuilderFields event

### DIFF
--- a/src/Builders/Schema.php
+++ b/src/Builders/Schema.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\ObjectType;
 use markhuot\CraftQL\Behaviors\SchemaBehavior;
 use markhuot\CraftQL\Request;
 use markhuot\CraftQL\Builders\Field as BaseField;
+use markhuot\CraftQL\Events\GetSchemaBuilderFields;
 
 class Schema extends BaseBuilder {
 
@@ -185,6 +186,10 @@ class Schema extends BaseBuilder {
     function getFields(): array {
         $this->boot();
         $this->bootBehaviors();
+
+        $event = new GetSchemaBuilderFields;
+        $this->trigger(GetSchemaBuilderFields::EVENT, $event);
+
         return $this->fields;
     }
 

--- a/src/Events/GetSchemaBuilderFields.php
+++ b/src/Events/GetSchemaBuilderFields.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace markhuot\CraftQL\Events;
+
+use yii\base\Event;
+use markhuot\CraftQL\Builders\Schema;
+
+class GetSchemaBuilderFields extends Event {
+
+    const EVENT = 'craftQlGetSchemaBuilderFields';
+
+    /**
+     * The schema being built
+     *
+     * @var Schema
+     */
+    public $sender;
+}


### PR DESCRIPTION
Fixes #137 

The goal here is to be able to add fields to CraftQL's core types/interfaces(https://github.com/markhuot/craftql/tree/master/src/Types).

Usage would look something like:

```php
        Event::on(
            \markhuot\CraftQL\Types\VolumeInterface::class,
            \markhuot\CraftQL\Events\GetSchemaBuilderFields::EVENT,
            function (\markhuot\CraftQL\Events\GetSchemaBuilderFields $event) {
                $interface = $event->sender;

                // Add something missing from the core type
                $interface->addStringField('kind');

                // Overwrite an existing field
                $interface->addStringField('title')
                    ->resolve(function ($root) {
                        return "My favorite {$root->kind}.";
                    });

                // Something totally custom
                $interface->addStringField('foo')
                    ->resolve(function ($root) {
                        return 'bar';
                    });
            }
        );
```