### PR TITLE
#144 allow for lists

### DIFF
--- a/src/FieldBehaviors/EntryQueryArguments.php
+++ b/src/FieldBehaviors/EntryQueryArguments.php
@@ -58,11 +58,11 @@ class EntryQueryArguments extends FieldBehavior {
         }
 
         $type = $this->owner->createInputObjectType('RelatedToInputType');
-        $type->addIntArgument('element');
+        $type->addIntArgument('element')->lists();
         $type->addBooleanArgument('elementIsEdge');
-        $type->addIntArgument('sourceElement');
+        $type->addIntArgument('sourceElement')->lists();
         $type->addBooleanArgument('sourceElementIsEdge');
-        $type->addIntArgument('targetElement');
+        $type->addIntArgument('targetElement')->lists();
         $type->addBooleanArgument('targetElementIsEdge');
         $type->addStringArgument('field');
         $type->addStringArgument('sourceLocale');


### PR DESCRIPTION
Allows us to supply lists to the element props:

```graphql
{
  entriesConnection(section: profile, relatedTo: [{element: 1}, {element: 2}, {element: [3, 4]}]) {
    totalCount
    entries {
      ... on Profile {
        title
      }
    }
  }
}
```