### PR TITLE
provide idNot operation for both int and array of int values

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -125,7 +125,8 @@ class Request {
         }
 
         if (!empty($args['idNot'])) {
-            $criteria->id('not '.implode(', ', $args['idNot']));
+            // this looks a little unusual to fit craft\helpers\Db::parseParam
+            $criteria->id('and, !='.implode(', !=', $args['idNot']));
             unset($args['idNot']);
         }
 


### PR DESCRIPTION
Mark, this looks like the actual upgrade to get idNot to perform with all values in arrays of ids.

I've tested with both plain ints and arrays of ints -- you'll  probably want to ;)