### PR TITLE
provide idNot operation for both int and array of int values

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -125,7 +125,8 @@ class Request {
         }
 
         if (!empty($args['idNot'])) {
-            $criteria->id('not '.implode(', ', $args['idNot']));
+            // this looks a little unusual to fit craft\helpers\Db::parseParam
+            $criteria->id('and, !='.implode(', !=', $args['idNot']));
             unset($args['idNot']);
         }
 


### PR DESCRIPTION
Mark, this repairs that present condition idNot accepts but does not use arrays of id Ints.

This was mentioned, but is not the subject of #132 -- it just fixes the omission, which appears to have happened because the form needed for the criteria building is a little unexpected.

This fix has been happy in use here, on my fork, and does the job needed for the first level of queries coming from Live Vue.

I've mentioned in clearing the first PR that I'd forgotten and used camelCase in the branch name, so this PR should work as expected with Composer. I had been testing with a filesystem repo, so missed this at first.

Thanks, Clive