### PR TITLE
Extract Access-Control-Allow-Headers to a setting.

### DIFF
--- a/src/Console/ToolsController.php
+++ b/src/Console/ToolsController.php
@@ -85,7 +85,8 @@ class ToolsController extends Controller
                             $headers['Access-Control-Allow-Origin'] = $origin;
                         }
                         $headers['Access-Control-Allow-Credentials'] = 'true';
-                        $headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type';
+                        $headers['Access-Control-Allow-Headers'] = implode(', ', CraftQL::getInstance()->getSettings()->allowedHeaders);
+
                     }
                     $headers['Allow'] = implode(', ', CraftQL::getInstance()->getSettings()->verbs);
 

--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -65,7 +65,7 @@ class ApiController extends Controller
                 $response->headers->set('Access-Control-Allow-Origin', $origin);
             }
             $response->headers->set('Access-Control-Allow-Credentials', 'true');
-            $response->headers->set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+            $response->headers->set('Access-Control-Allow-Headers', implode(', ', CraftQL::getInstance()->getSettings()->allowedHeaders));
         }
         $response->headers->set('Allow', implode(', ', CraftQL::getInstance()->getSettings()->verbs));
 

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -11,6 +11,7 @@ class Settings extends Model
     public $uri = 'api';
     public $verbs = ['POST'];
     public $allowedOrigins = [];
+    public $allowedHeaders = ['Authorization, Content-Type'];
     public $headers = [];
     public $maxQueryDepth = false;
     public $maxQueryComplexity = false;


### PR DESCRIPTION
I needed to allow requests to contain a `Surrogate-Key` header for some caching mechanisms.