### PR TITLE
Extended EntryInterface fields

### DIFF
--- a/src/Types/EntryInterface.php
+++ b/src/Types/EntryInterface.php
@@ -5,6 +5,7 @@ namespace markhuot\CraftQL\Types;
 use markhuot\CraftQL\Builders\InterfaceBuilder;
 use markhuot\CraftQL\FieldBehaviors\EntryQueryArguments;
 use markhuot\CraftQL\Helpers\StringHelper;
+use Craft;
 
 class EntryInterface extends InterfaceBuilder {
 
@@ -26,13 +27,59 @@ class EntryInterface extends InterfaceBuilder {
         $this->addStringField('uri');
         $this->addStringField('url');
 
+        $this->addStringField('fullUri')
+            ->resolve(function($root, $args) {
+                $site = Craft::$app->sites->getSiteById($root->siteId);
+                return $root->uri ? rtrim(
+                    str_replace(
+                        '__home__',
+                        '',
+                        str_replace(
+                            '@web',
+                            '',
+                            $site->baseUrl . $root->uri
+                        )
+                    ),
+                    '/'
+                ) : null;
+            });
+        
+        $this->addField('site')->type(Site::class);
+
+        $this->addField('supportedSites')->lists()->type(Site::class)
+            ->resolve(function ($root, $args) {
+                return array_map(function ($site) {
+                    return Craft::$app->sites->getSiteById($site['siteId']);
+                }, $root['supportedSites']);
+            });
+
+        $this->addField('alternateEntries')->lists()->type(EntryInterfaceAlternate::class)
+            ->resolve(function ($root, $args) {
+                return array_map(function ($site) use ($root) {
+                    $entry = Craft::$app->entries->getEntryById($root->id, $site['siteId']);
+                    return (object) [
+                        'entry' => $entry,
+                        'isSelf' => $root->siteId == $entry->siteId
+                    ];
+                }, $root['supportedSites']);
+                // return array_filter($allEntries, function($entry) {
+                //     return $entry->enabled;
+                // });
+            });
+
+        $this->addStringField('language')
+            ->resolve(function($root, $args) {
+                $site = Craft::$app->sites->getSiteById($root->siteId);
+                return $site->language;
+            });
+
         if ($this->request->token()->can('query:sections')) {
             $this->addField('section')->type(Section::class);
             $this->addField('type')->type(EntryType::class);
         }
 
         $this->addField('ancestors')->lists()->type(EntryInterface::class);
-
+        
         $this->addField('children')
             ->lists()
             ->type(EntryInterface::class)

--- a/src/Types/EntryInterfaceAlternate.php
+++ b/src/Types/EntryInterfaceAlternate.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace markhuot\CraftQL\Types;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\EnumType;
+use GraphQL\Type\Definition\Type;
+use markhuot\CraftQL\Builders\Schema;
+
+class EntryInterfaceAlternate extends Schema {
+
+    function boot() {
+        $this->addField('entry')->type(EntryInterface::class);
+        $this->addBooleanField('isSelf')->nonNull();
+    }
+
+}


### PR DESCRIPTION
Hej, thank you for this plugin! We're using it to make craft truly headless.

We ran into a few problems that we needed to solve:

- The `uri` field is `"__home__"` for the home page which is not particularly useful if you're not craft
- The `uri` field does not contain the url prefix from sites (which are used for languages in our case [/en, /de])
- The `url` field does contain the language prefix, but therefore also contains the full incl. "https://something.bla/", which again is not particularly helpful since the frontend is not necessarily hosted where the cms is
- There is no way (coming from an Entry) to figure out to which site it belongs
- There is no way (coming from an Entry) to figure out what the entries with the same id's for other sites are. (Example: "I'm the English version of an Entry, what are the Entries in other Languages related to me.")

To solve this I've added some fields:

- `fullUri` contains a fully qualified url no matter what.
- `site` is just the site the entry belongs to
- `supportedSites ` is the array of supportedSites (copied from craft)
- `alternateEntries` is an Array of a new Type called `EntryInterfaceAlternate` that just contains an Entry and a boolean `isSelf`. The entries are the ones with the same id in all sites where the entry is active. Think of this as enabling you to simply render site (language) switcher based on that data.
- `language` is just a convenience field that pulls the language from the site. (Yea... kinda unnecessary — I'm actually indifferent about this one)


This code is more or less a proof of concept and I'm almost certain that my implementation is not very nice and might have some quirks. Nevertheless I'd love to make CraftQL more helpful for us.

Do you think those (or some of those) additions make sense?

How can I improve them?

If some additions do not make sense... is there a way to extend the Schema like this without needing to fork CraftQL?

Let's talk :)

Screenshot of how it looks currently:
<img width="1694" alt="Entry Additions" src="https://user-images.githubusercontent.com/5230863/47789785-d442cf00-dd15-11e8-895c-893b5e94e9d9.png">
