### PR TITLE
Confine token save to Settings model to avoid conflicts.

### DIFF
--- a/src/CraftQL.php
+++ b/src/CraftQL.php
@@ -111,21 +111,4 @@ class CraftQL extends Plugin
             'settings' => $this->getSettings()
         ]);
     }
-
-    /**
-     * Save the settings, some custom work here to make sure token names
-     * are saved correctly
-     */
-    public function setSettings(array $settings)
-    {
-        parent::setSettings($settings);
-
-        if (isset($_POST['settings']['token'])) {
-            foreach ($_POST['settings']['token'] as $tokenId => $values) {
-                $token = Token::find()->where(['id' => $tokenId])->one();
-                $token->name = @$values['name'];
-                $token->save();
-            }
-        }
-    }
 }

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -30,4 +30,23 @@ class Settings extends Model
         $tokens = Token::find()->where(['userId' => \Craft::$app->user->id])->all();
         return $tokens;
     }
+
+    /**
+     * Make sure token names are saved correctly along with this model.
+     * 
+     * @inheritdoc
+     */
+    public function beforeValidate()
+    {
+        if (isset($_POST['settings']['token'])) {
+            foreach ($_POST['settings']['token'] as $tokenId => $values) {
+                $token = Token::find()->where(['id' => $tokenId])->one();
+                $token->name = @$values['name'];
+                $token->save();
+            }
+        }
+
+        return parent::beforeValidate();
+    }
+
 }


### PR DESCRIPTION
Fixes #237.

Works fine! CraftQL settings can be re-saved from the control panel and a newly-created token's name is saved+maintained. Saving _another plugin's_ settings using `setting.token` no longer throws an exception.