### PR TITLE
Use the new Paginator for pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## dev-master
 
-- (none)
+### Changed
+
+- CraftQL now requires Craft 3.1.19+.
+
+### Fixed
+
+- Fixed an error that occurred on Craft 3.1.19+. ([#248](https://github.com/markhuot/craftql/issues/248))
+- Fixed a bug where pagination limits weren’t being respected. 
 
 ## 1.3.1 - 2019-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Fixed an error that occurred on Craft 3.1.19+. ([#248](https://github.com/markhuot/craftql/issues/248))
+- Fixed an error that occurred when fetching categories.
 - Fixed a bug where pagination limits weren’t being respected. 
 
 ## 1.3.1 - 2019-01-29

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ No software is ever done. There's a lot still to do in order to make _CraftQL_ f
 
 ## Requirements
 
-- Craft 3.0.0-RC1
+- Craft 3.1.19+
 - PHP 7.0+
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "craft-plugin"
     ],
     "require": {
-        "craftcms/cms": "^3.0.0",
+        "craftcms/cms": "^3.1.19",
         "webonyx/graphql-php": "^0.11.0",
         "react/http": "^0.7"
     },

--- a/src/FieldBehaviors/RelatedCategoriesField.php
+++ b/src/FieldBehaviors/RelatedCategoriesField.php
@@ -2,9 +2,8 @@
 
 namespace markhuot\CraftQL\FieldBehaviors;
 
-use craft\db\Paginator;
-use craft\web\twig\variables\Paginate;
 use markhuot\CraftQL\Behaviors\SchemaBehavior;
+use markhuot\CraftQL\TypeModels\PageInfo;
 use markhuot\CraftQL\Types\CategoryConnection;
 use markhuot\CraftQL\Types\EntryConnection;
 
@@ -25,15 +24,14 @@ class RelatedCategoriesField extends SchemaBehavior {
                     $criteria->relatedTo(@$root['node']->id);
                 }
 
-                $paginator = new Paginator($criteria, [
-                    'pageSize' => @$args['limit'] ?: 100,
-                    'currentPage' => \Craft::$app->request->pageNum,
-                ]);
+                $totalCount = $criteria->count();
+                $offset = @$args['offset'] ?: 0;
+                $perPage = @$args['limit'] ?: 100;
 
                 return [
-                    'totalCount' => $paginator->getTotalResults(),
-                    'pageInfo' => Paginate::create($paginator),
-                    'edges' => $paginator->getPageResults(),
+                    'totalCount' => $totalCount,
+                    'pageInfo' => new PageInfo($offset, $perPage, $totalCount),
+                    'edges' => $criteria->all(),
                 ];
             });
     }

--- a/src/FieldBehaviors/RelatedCategoriesField.php
+++ b/src/FieldBehaviors/RelatedCategoriesField.php
@@ -2,6 +2,8 @@
 
 namespace markhuot\CraftQL\FieldBehaviors;
 
+use craft\db\Paginator;
+use craft\web\twig\variables\Paginate;
 use markhuot\CraftQL\Behaviors\SchemaBehavior;
 use markhuot\CraftQL\Types\CategoryConnection;
 use markhuot\CraftQL\Types\EntryConnection;
@@ -23,13 +25,15 @@ class RelatedCategoriesField extends SchemaBehavior {
                     $criteria->relatedTo(@$root['node']->id);
                 }
 
-                list($pageInfo, $categories) = \craft\helpers\Template::paginateCriteria($criteria);
-                $pageInfo->limit = @$args['limit'] ?: 100;
+                $paginator = new Paginator($criteria, [
+                    'pageSize' => @$args['limit'] ?: 100,
+                    'currentPage' => \Craft::$app->request->pageNum,
+                ]);
 
                 return [
-                    'totalCount' => $pageInfo->total,
-                    'pageInfo' => $pageInfo,
-                    'edges' => $categories,
+                    'totalCount' => $paginator->getTotalResults(),
+                    'pageInfo' => Paginate::create($paginator),
+                    'edges' => $paginator->getPageResults(),
                 ];
             });
     }

--- a/src/FieldBehaviors/RelatedEntriesField.php
+++ b/src/FieldBehaviors/RelatedEntriesField.php
@@ -2,9 +2,8 @@
 
 namespace markhuot\CraftQL\FieldBehaviors;
 
-use craft\db\Paginator;
-use craft\web\twig\variables\Paginate;
 use markhuot\CraftQL\Behaviors\SchemaBehavior;
+use markhuot\CraftQL\TypeModels\PageInfo;
 use markhuot\CraftQL\Types\EntryConnection;
 
 class RelatedEntriesField extends SchemaBehavior {
@@ -20,15 +19,14 @@ class RelatedEntriesField extends SchemaBehavior {
                     $criteria->relatedTo(@$root['node']->id);
                 }
 
-                $paginator = new Paginator($criteria, [
-                    'pageSize' => @$args['limit'] ?: 100,
-                    'currentPage' => \Craft::$app->request->pageNum,
-                ]);
+                $totalCount = $criteria->count();
+                $offset = @$args['offset'] ?: 0;
+                $perPage = @$args['limit'] ?: 100;
 
                 return [
-                    'totalCount' => $paginator->getTotalResults(),
-                    'pageInfo' => Paginate::create($paginator),
-                    'edges' => $paginator->getPageResults(),
+                    'totalCount' => $totalCount,
+                    'pageInfo' => new PageInfo($offset, $perPage, $totalCount),
+                    'edges' => $criteria->all(),
                 ];
             });
     }

--- a/src/FieldBehaviors/RelatedEntriesField.php
+++ b/src/FieldBehaviors/RelatedEntriesField.php
@@ -2,6 +2,8 @@
 
 namespace markhuot\CraftQL\FieldBehaviors;
 
+use craft\db\Paginator;
+use craft\web\twig\variables\Paginate;
 use markhuot\CraftQL\Behaviors\SchemaBehavior;
 use markhuot\CraftQL\Types\EntryConnection;
 
@@ -18,13 +20,15 @@ class RelatedEntriesField extends SchemaBehavior {
                     $criteria->relatedTo(@$root['node']->id);
                 }
 
-                list($pageInfo, $entries) = \craft\helpers\Template::paginateCriteria($criteria);
-                $pageInfo->limit = @$args['limit'] ?: 100;
+                $paginator = new Paginator($criteria, [
+                    'pageSize' => @$args['limit'] ?: 100,
+                    'currentPage' => \Craft::$app->request->pageNum,
+                ]);
 
                 return [
-                    'totalCount' => $pageInfo->total,
-                    'pageInfo' => $pageInfo,
-                    'edges' => $entries,
+                    'totalCount' => $paginator->getTotalResults(),
+                    'pageInfo' => Paginate::create($paginator),
+                    'edges' => $paginator->getPageResults(),
                 ];
             });
     }

--- a/src/TypeModels/PageInfo.php
+++ b/src/TypeModels/PageInfo.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace markhuot\CraftQL\TypeModels;
+
+class PageInfo {
+
+    protected $offset;
+    protected $perPage;
+    protected $total;
+
+    public $currentPage;
+    public $totalPages;
+    public $first;
+    public $last;
+
+    function __construct($offset, $perPage, $total) {
+        $this->offset = $offset;
+        $this->perPage = $perPage;
+        $this->total = $total;
+
+        $this->currentPage = floor($this->offset / $this->perPage) + 1;
+        $this->totalPages = ceil($this->total / $this->perPage);
+
+        // normally currentPage starts at 1, but if there are 0 pages, then drop it down
+        if ($this->totalPages == 0) {
+            $this->currentPage = 0;
+        }
+
+        $this->first = $this->offset;
+        $this->last = min($this->total, $this->offset + $this->perPage);
+    }
+
+}

--- a/src/Types/CategoryEdge.php
+++ b/src/Types/CategoryEdge.php
@@ -30,7 +30,7 @@ class CategoryEdge extends Schema {
             ->type(CategoryConnection::class)
             ->use(new CategoryQueryArguments)
             ->resolve(function ($root, $args, $context, $info) {
-                $paginator = new Paginator(CategoryInterface::criteriaResolver($root, $args, $context, $info, $root['node']->getChildren()), [
+                $paginator = new Paginator(CategoryInterface::criteriaResolver($root, $args, $context, $info, $root['node']->getChildren(), false), [
                     'pageSize' => @$args['limit'] ?: 100,
                     'currentPage' => \Craft::$app->request->pageNum,
                 ]);

--- a/src/Types/CategoryEdge.php
+++ b/src/Types/CategoryEdge.php
@@ -3,8 +3,6 @@
 namespace markhuot\CraftQL\Types;
 
 // use GraphQL\Type\Definition\ObjectType;
-use craft\db\Paginator;
-use craft\web\twig\variables\Paginate;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\Type;
@@ -12,6 +10,7 @@ use markhuot\CraftQL\FieldBehaviors\CategoryQueryArguments;
 use markhuot\CraftQL\Request;
 use markhuot\CraftQL\Builders\Schema;
 use markhuot\CraftQL\FieldBehaviors\RelatedEntriesField;
+use markhuot\CraftQL\TypeModels\PageInfo;
 
 class CategoryEdge extends Schema {
 
@@ -30,15 +29,15 @@ class CategoryEdge extends Schema {
             ->type(CategoryConnection::class)
             ->use(new CategoryQueryArguments)
             ->resolve(function ($root, $args, $context, $info) {
-                $paginator = new Paginator(CategoryInterface::criteriaResolver($root, $args, $context, $info, $root['node']->getChildren(), false), [
-                    'pageSize' => @$args['limit'] ?: 100,
-                    'currentPage' => \Craft::$app->request->pageNum,
-                ]);
+                $criteria = CategoryInterface::criteriaResolver($root, $args, $context, $info, $root['node']->getChildren(), false);
+                $totalCount = $criteria->count();
+                $offset = @$args['offset'] ?: 0;
+                $perPage = @$args['limit'] ?: 100;
 
                 return [
-                    'totalCount' => $paginator->getTotalResults(),
-                    'pageInfo' => Paginate::create($paginator),
-                    'edges' => $paginator->getPageResults(),
+                    'totalCount' => $totalCount,
+                    'pageInfo' => new PageInfo($offset, $perPage, $totalCount),
+                    'edges' => $criteria->all(),
                 ];
             });
     }

--- a/src/Types/CategoryInterface.php
+++ b/src/Types/CategoryInterface.php
@@ -28,7 +28,7 @@ class CategoryInterface extends InterfaceBuilder {
             ->type(CategoryConnection::class)
             ->use(new CategoryQueryArguments)
             ->resolve(function ($root, $args, $context, $info) {
-                $paginator = new Paginator(static::criteriaResolver($root, $args, $context, $info, $root->getChildren()), [
+                $paginator = new Paginator(static::criteriaResolver($root, $args, $context, $info, $root->getChildren(), false), [
                     'pageSize' => @$args['limit'] ?: 100,
                     'currentPage' => \Craft::$app->request->pageNum,
                 ]);
@@ -52,7 +52,7 @@ class CategoryInterface extends InterfaceBuilder {
         };
     }
 
-    static function criteriaResolver($root, $args, $context, $info, $criteria=null) {
+    static function criteriaResolver($root, $args, $context, $info, $criteria=null, $asArray=true) {
         $criteria = $criteria ?: \craft\elements\Category::find();
 
         if (isset($args['group'])) {
@@ -64,7 +64,7 @@ class CategoryInterface extends InterfaceBuilder {
             $criteria = $criteria->{$key}($value);
         }
 
-        return $criteria->all();
+        return $asArray ? $criteria->all() : $criteria;
     }
 
 }

--- a/src/Types/PageInfo.php
+++ b/src/Types/PageInfo.php
@@ -2,7 +2,6 @@
 
 namespace markhuot\CraftQL\Types;
 
-use craft\web\twig\variables\Paginate;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\EnumType;
@@ -24,11 +23,7 @@ class PageInfo extends Schema {
             return $root->currentPage < $root->totalPages;
         });
 
-        $this->addIntField('currentPage')
-            ->resolve(function (Paginate $root, $args, $context, $info) {
-                return floor(($root->first - 1) / (@$root->limit ?: 100)) + 1;
-            });
-
+        $this->addIntField('currentPage');
         $this->addIntField('totalPages');
         $this->addIntField('first');
         $this->addIntField('last');


### PR DESCRIPTION
Fixes #248 and pagination in general

(I haven’t actually tested any of this, and it wasn’t clear whether CraftQL is actually using the main Craft page number like `{% paginate %}` tags to get the current page. That’s how it “worked” beforehand, anyway.)