### PR TITLE
adds support for querying assets by multiple ids

### DIFF
--- a/src/FieldBehaviors/AssetQueryArguments.php
+++ b/src/FieldBehaviors/AssetQueryArguments.php
@@ -12,7 +12,7 @@ class AssetQueryArguments extends FieldBehavior {
         $this->owner->addBooleanArgument('fixedOrder');
         $this->owner->addIntArgument('folderId');
         $this->owner->addIntArgument('height');
-        $this->owner->addIntArgument('id');
+        $this->owner->addIntArgument('id')->lists();
         $this->owner->addStringArgument('kind');
         $this->owner->addIntArgument('limit');
         $this->owner->addStringArgument('locale');


### PR DESCRIPTION
Hello,

I have a project that has a "lightbox" feature, so I need to track the ids of multiple assets, and then would like to make a single query based on those ids. This PR just adds the `lists()` method to match the Category query. Tested locally and it adds the feature as expected.

ps. this is my first PR so I hope I've done it right.

pps. this is my first project with craft and graphql - this plugin is just brilliant. Thanks you!