### PR TITLE
Fixed draft querying in Craft 3.2.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ### Changed
 
-- CraftQL now requires Craft 3.1.19+.
+- CraftQL now requires Craft 3.2.0+.
 
 ### Fixed
 
 - Fixed an error that occurred on Craft 3.1.19+. ([#248](https://github.com/markhuot/craftql/issues/248))
+- Fixed an error that occurred on Craft 3.2.0+ when querying for entry drafts, if the `name` or `notes` fields were specified.
 - Fixed an error that occurred when fetching categories.
 - Fixed a bug where pagination limits weren’t being respected. 
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ No software is ever done. There's a lot still to do in order to make _CraftQL_ f
 
 ## Requirements
 
-- Craft 3.1.19+
+- Craft 3.2.0+
 - PHP 7.0+
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "craft-plugin"
     ],
     "require": {
-        "craftcms/cms": "^3.1.19",
+        "craftcms/cms": "^3.2.0",
         "webonyx/graphql-php": "^0.11.0",
         "react/http": "^0.7"
     },

--- a/src/Types/EntryDraftInfo.php
+++ b/src/Types/EntryDraftInfo.php
@@ -2,6 +2,7 @@
 
 namespace markhuot\CraftQL\Types;
 
+use craft\behaviors\DraftBehavior;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\EnumType;
@@ -12,10 +13,15 @@ class EntryDraftInfo extends Schema {
 
     function boot() {
         $this->addIntField('draftId');
-        $this->addStringField('name');
+        $this->addStringField('name')
+            ->resolve(function ($root, $args) {
+                /** @var DraftBehavior $root */
+                return $root->draftName;
+            });
         $this->addStringField('notes')
             ->resolve(function ($root, $args) {
-                return $root->revisionNotes;
+                /** @var DraftBehavior $root */
+                return $root->draftNotes;
             });
     }
 


### PR DESCRIPTION
Draft names & notes go by `draftName` and `draftNotes` in Craft 3.2, so a slight tweak is needed on CraftQL’s end in order to continue supporting draft `name` and `notes` fields.