### PR TITLE
Fix graphiqlFetchUrl settings

### DIFF
--- a/src/Controllers/CpController.php
+++ b/src/Controllers/CpController.php
@@ -56,7 +56,7 @@ class CpController extends Controller
     function actionGraphiql()
     {
         $instance = \markhuot\CraftQL\CraftQL::getInstance();
-        $graphiqlFetchUrl = $instance->settings->graphiqlFetchUrl ?? \craft\helpers\UrlHelper::siteUrl();
+        $graphiqlFetchUrl = $instance->settings->graphiqlFetchUrl ?? \craft\helpers\UrlHelper::baseCpUrl();
         $uri = $instance->settings->uri;
 
         $this->view->registerAssetBundle(GraphiQLAssetBundle::class);
@@ -70,7 +70,7 @@ class CpController extends Controller
     function actionGraphiqlas($token)
     {
         $instance = \markhuot\CraftQL\CraftQL::getInstance();
-        $graphiqlFetchUrl = $instance->settings->graphiqlFetchUrl ?? \craft\helpers\UrlHelper::siteUrl();
+        $graphiqlFetchUrl = $instance->settings->graphiqlFetchUrl ?? \craft\helpers\UrlHelper::baseCpUrl();
         $uri = $instance->settings->uri;
 
         $this->view->registerAssetBundle(GraphiQLAssetBundle::class);

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -77,6 +77,14 @@ You can access your GraphQL endpoint in two ways,
         instructions: 'The URI to the GraphQL service. Typically this is `api` but you can override it with your own preference.',
     }) }}
 
+    <h2>Graphiql Fetch Url</h2>
+
+    {{ forms.textField({
+        name: 'graphiqlFetchUrl',
+        value: settings.graphiqlFetchUrl,
+        instructions: 'The Base url to use for the graphiql requests. Defaults to Craft's baseCpUrl()',
+    }) }}
+
     <h2>Tokens</h2>
     <p>Tokens control access in to your API. Instead of authenticating with a username and password, API access is granted via a token. Treat this token like a password because it provides privileged access in to your Craft website.</p>
 


### PR DESCRIPTION
- Added ability to set-up graphiqlFetchUrl on settings page
- Fixed default graphiqlFetchUrl to point to CMS' base url instead of page base. That was causing issues when using Craft as headless and pointing Page base to the frontend site.