### PR TITLE
Require graphql-php ^0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "craftcms/cms": "^3.1.19",
-        "webonyx/graphql-php": "^0.11.0",
+        "webonyx/graphql-php": "^0.12.0",
         "react/http": "^0.7"
     },
     "authors": [


### PR DESCRIPTION
Craft 3.3.0 requires `webonyx/graphql-php ^0.12.0`, which conflicts with CraftQL’s `^0.11.0` requirement.

0.12.0 is still compatible with PHP 7.0 and seems to [not introduce any breaking changes](https://github.com/webonyx/graphql-php/blob/master/CHANGELOG.md#v0120), so it should be safe to update.