### PR TITLE
Fixed Craft 3.5 / Yii 2.0.36 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+- Fixed Craft 3.5 compatibility. ([#338](https://github.com/markhuot/craftql/issues/338))
+
 ## 1.3.4 - 2019-08-29
 
 ### Fixed

--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -12,7 +12,6 @@ class ApiController extends Controller
     protected $allowAnonymous = ['index'];
 
     private $graphQl;
-    private $request;
 
     function __construct(
         $id,


### PR DESCRIPTION
`markhuot\CraftQL\Controllers\ApiController::$request` is never used, and conflicts with yii\base\Controller::$request

Fixes #338