### PR TITLE
Craft 3.6 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Unreleased
 
-### Fixed
+## Unreleased
+
+- Fixed Craft 3.6 compatibility.
+- Updated graphql-php to v14.
+
+## 1.3.5 - 2020-08-14
+
 - Fixed Craft 3.5 compatibility. ([#338](https://github.com/markhuot/craftql/issues/338))
 
 ## 1.3.4 - 2019-08-29

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ No software is ever done. There's a lot still to do in order to make _CraftQL_ f
 
 ## Requirements
 
-- Craft 3.2.0+
+- Craft 3.6.0+
 - PHP 7.0+
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         "craft-plugin"
     ],
     "require": {
-        "craftcms/cms": "^3.2.0",
-        "webonyx/graphql-php": "^0.12.0",
+        "craftcms/cms": "^3.6.0",
+        "webonyx/graphql-php": "^14.4.1",
         "react/http": "^0.7"
     },
     "authors": [

--- a/src/Services/GraphQLService.php
+++ b/src/Services/GraphQLService.php
@@ -4,7 +4,7 @@ namespace markhuot\CraftQL\Services;
 
 use Craft;
 use GraphQL\GraphQL;
-use GraphQL\Error\Debug;
+use GraphQL\Error\DebugFlag;
 use GraphQL\Type\Schema;
 use GraphQL\Validator\DocumentValidator;
 use GraphQL\Validator\Rules\QueryComplexity;
@@ -128,7 +128,7 @@ class GraphQLService extends Component {
     }
 
     function execute($schema, $input, $variables = []) {
-        $debug = Craft::$app->config->getGeneral()->devMode ? Debug::INCLUDE_DEBUG_MESSAGE | Debug::RETHROW_INTERNAL_EXCEPTIONS : null;
+        $debug = Craft::$app->config->getGeneral()->devMode ? DebugFlag::INCLUDE_DEBUG_MESSAGE | DebugFlag::RETHROW_INTERNAL_EXCEPTIONS : null;
         return GraphQL::executeQuery($schema, $input, null, null, $variables)->toArray($debug);
     }
 


### PR DESCRIPTION
Craft 3.6 bundles graphql-php 14.4.1+, so CraftQL needs to follow suit to avoid Composer conflicts.

v14 had a few [breaking changes](https://github.com/webonyx/graphql-php/blob/master/CHANGELOG.md#v1400), only one of which affected CraftQL as far as I could tell (`GraphQL\Error\Debug` → `GraphQL\Error\DebugFlag`). I verified that a basic API request still works via the bundled GraphiQL.